### PR TITLE
Resolve YCM and UltiSnips conflict

### DIFF
--- a/vim/plugin/settings/main.vim
+++ b/vim/plugin/settings/main.vim
@@ -60,3 +60,9 @@ autocmd BufNewFile,BufReadPost *.html,*.css,*.scss,*.js setlocal softtabstop=2 s
 
 " Resize splits when the window is resized
 au VimResized * exe "normal! \<c-w>="
+
+" Resolve YouCompleteMe and UltiSnips conflict
+let g:ycm_key_list_select_completion = ['\<C-TAB>', '\<Down>']
+let g:ycm_key_list_previous_completion = ['\<C-S-TAB>', '\<Up>']
+
+let g:SuperTabDefaultCompletionType = '\<C-Tab>'

--- a/vimrc
+++ b/vimrc
@@ -44,6 +44,9 @@ Plugin 'tpope/vim-surround'
 Plugin 'tpope/vim-eunuch'
 Plugin 'vim-scripts/Gundo'
 
+Plugin 'ervandew/supertab'
+
 call vundle#end()
 
 filetype plugin indent on     " Required!
+


### PR DESCRIPTION
YCM and Ultisnips both use TAB key to do their things. Sometimes
they are in conflict. I found the solution here:
http://0x3f.org/blog/make-youcompleteme-ultisnips-compatible/

Now, if there are multiple snippets that match, you can choose one
by pressing C-n or C-p as usual, and expand it with TAB.